### PR TITLE
Fixed a bug where AMEX CVC numbers won't validate.

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -27,7 +27,7 @@ class ServiceProvider extends BaseServiceProvider
         });
 
         \Validator::extend('cvc', function($attribute, $value, $parameters, $validator) {
-            return ctype_digit($value) && strlen($value) == 3;
+            return ctype_digit($value) && (strlen($value) == 3 || strlen($value) == 4);
         });
     }
     


### PR DESCRIPTION
AMEX CVC/CCV numbers are 4 digits long.
